### PR TITLE
No need for --save anymore

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Easily get the latest exchange data of Bitcoin, Etherium, Litecoin, and other as
 ## Install
 
 ```bash
-$ npm install --save coin-ticker
+$ npm install coin-ticker
 ```
 
 ## Usage


### PR DESCRIPTION
# https://docs.npmjs.com/cli/install
---
```
npm install (in package directory, no arguments):

Install the dependencies in the local node_modules folder.

In global mode (ie, with -g or --global appended to the command), it installs the current package context (ie, the current working directory) as a global package.

By default, npm install will install all modules listed as dependencies in package.json.

npm install saves any specified packages into dependencies by default. Additionally, you can control where and how they get saved with some additional flags:

-P, --save-prod: Package will appear in your dependencies. This is the default unless -D or -O are present.

-D, --save-dev: Package will appear in your devDependencies.

-O, --save-optional: Package will appear in your optionalDependencies.

--no-save: Prevents saving to dependencies.

When using any of the above options to save dependencies to your package.json, there are two additional, optional flags:

-E, --save-exact: Saved dependencies will be configured with an exact version rather than using npm's default semver range operator.

-B, --save-bundle: Saved dependencies will also be added to your bundleDependencies list.
```